### PR TITLE
Fix the late pop issue for buildings

### DIFF
--- a/mods/default/init.lua
+++ b/mods/default/init.lua
@@ -7,6 +7,7 @@ WATER_ALPHA = 160
 WATER_VISC = 1
 LAVA_VISC = 7
 LIGHT_MAX = 14
+SAVEDIR = "LOTT"
 
 -- Definitions made by this mod that other mods can use too
 default = {}

--- a/mods/lottmapgen/init.lua
+++ b/mods/lottmapgen/init.lua
@@ -93,6 +93,8 @@ local mapgen_params = minetest.get_mapgen_params()
 dofile(minetest.get_modpath("lottmapgen").."/nodes.lua")
 dofile(minetest.get_modpath("lottmapgen").."/functions.lua")
 
+dofile(minetest.get_modpath("lottmapgen").."/schematics.lua")
+
 -- On generated function
 minetest.register_on_generated(function(minp, maxp, seed)
 	if minp.y < (mapgen_params.water_level-1000) or minp.y > 5000 then
@@ -155,15 +157,6 @@ minetest.register_on_generated(function(minp, maxp, seed)
 	local c_pilinehtar = minetest.get_content_id("lottplants:pilinehtar")
 	local c_ithilgrass = minetest.get_content_id("lottmapgen:ithilien_grass")
 	local c_melon = minetest.get_content_id("lottplants:melon_wild")
-	local c_angfort = minetest.get_content_id("lottmapgen:angmarfort")
-	local c_gonfort = minetest.get_content_id("lottmapgen:gondorfort")
-	local c_hobhole = minetest.get_content_id("lottmapgen:hobbithole")
-	local c_orcfort = minetest.get_content_id("lottmapgen:orcfort")
-	local c_malltre = minetest.get_content_id("lottmapgen:mallornhouse")
-	local c_lorhous = minetest.get_content_id("lottmapgen:lorienhouse")
-	local c_mirktre = minetest.get_content_id("lottmapgen:mirkhouse")
-	local c_rohfort = minetest.get_content_id("lottmapgen:rohanfort")
-	local c_dwahous = minetest.get_content_id("lottmapgen:dwarfhouse")
 
 	local sidelen = x1 - x0 + 1
 	local chulens = {x=sidelen, y=sidelen, z=sidelen}
@@ -233,7 +226,7 @@ minetest.register_on_generated(function(minp, maxp, seed)
 					end
 					if y > - 40 and y < -5 and biome == 11 then
 						if math.random(PLANT14) == 1 then
-							data[vi] = c_dwahous
+							lottmapgen.enqueue_building("Dwarf House", {x=x, y=y, z=z}) -- data[vi] = c_dwahous
 						end
 					end
 					if not solid then -- if surface
@@ -317,7 +310,7 @@ minetest.register_on_generated(function(minp, maxp, seed)
 										elseif math.random(PLANT6) == 2 then
 											data[vi] = c_seregon
 										elseif math.random(PLANT13) == 13 then
-											data[vi] = c_angfort
+											lottmapgen.enqueue_building("Angmar Fort", {x=x, y=y, z=z}) -- data[vi] = c_angfort
 										end
 									elseif biome == 2 then
 										data[vi] = c_snowblock
@@ -361,7 +354,7 @@ minetest.register_on_generated(function(minp, maxp, seed)
 										elseif math.random(PLANT6) == 2 then
 											data[vi] = c_mallos
 										elseif math.random(PLANT13) == 13 then
-											data[vi] = c_gonfort
+											lottmapgen.enqueue_building("Gondor Fort", {x=x, y=y, z=z})
 										end
 									elseif biome == 6 then
 										if math.random(TREE3) == 2 then
@@ -396,9 +389,9 @@ minetest.register_on_generated(function(minp, maxp, seed)
 											lottmapgen_lorienplants(data, vi)
 										elseif math.random(PLANT13) == 13 then
 											if math.random(1, 2) == 1 then
-												data[vi] = c_malltre
+												lottmapgen.enqueue_building("Mallorn House", {x=x, y=y, z=z})
 											else
-												data[vi] = c_lorhous
+												lottmapgen.enqueue_building("Lorien House", {x=x, y=y, z=z})
 											end
 										end
 									elseif biome == 8 then
@@ -407,7 +400,7 @@ minetest.register_on_generated(function(minp, maxp, seed)
 										elseif math.random(PLANT4) == 2 then
 											data[vi] = c_bomordor
 										elseif math.random(PLANT13) == 13 then
-											data[vi] = c_orcfort
+											lottmapgen.enqueue_building("Orc Fort", {x=x, y=y, z=z})
 										end
 									elseif biome == 9 then
 										if math.random(TREE3) == 2 then
@@ -463,7 +456,7 @@ minetest.register_on_generated(function(minp, maxp, seed)
 										elseif math.random(PLANT6) == 2 then
 											data[vi] = c_pilinehtar
 										elseif math.random(PLANT13) == 13 then
-											data[vi] = c_rohfort
+											lottmapgen.enqueue_building("Rohan Fort", {x=x, y=y, z=z})
 										end
 									elseif biome == 13 then
 										if math.random(TREE7) == 2 then
@@ -479,7 +472,7 @@ minetest.register_on_generated(function(minp, maxp, seed)
 										elseif math.random(PLANT9) == 8 then
 											data[vi] = c_melon
 										elseif math.random(PLANT13) == 13 then
-											data[vi] = c_hobhole
+											lottmapgen.enqueue_building("Hobbit Hole", {x=x, y=y, z=z})
 										end
 									end
 								end
@@ -527,6 +520,5 @@ minetest.register_on_generated(function(minp, maxp, seed)
 	local chugent = math.ceil((os.clock() - t1) * 1000)
 end)
 
-dofile(minetest.get_modpath("lottmapgen").."/schematics.lua")
 dofile(minetest.get_modpath("lottmapgen").."/deco.lua")
 dofile(minetest.get_modpath("lottmapgen").."/chests.lua")

--- a/mods/lottmapgen/init.lua
+++ b/mods/lottmapgen/init.lua
@@ -428,7 +428,7 @@ minetest.register_on_generated(function(minp, maxp, seed)
 										elseif math.random(TREE2) == 3 then
 											lottmapgen_jungletree2(x, y, z, area, data)
 										elseif math.random(PLANT13) == 13 then
-											data[vi] = c_mirktre
+											data[vi] = lottmapgen.enqueue_building("Mirkwood House", {x=x, y=y, z=z})
 										end
 									elseif biome == 11 then
 										if math.random(TREE10) == 2 then

--- a/mods/lottmapgen/schematics.lua
+++ b/mods/lottmapgen/schematics.lua
@@ -8,31 +8,23 @@ local protect_houses = minetest.setting_getbool("protect_structures") or false
 local lottmapgen_list = {
 	["Angmar Fort"] =    {build="angmarfort",   area_owner = "Orc Guard",     area_name = "Angmar Fort",   
 		center = {x=9, y=2, z=3} },
-		--bbox = {xmin = -4, ymin = -15, zmin = -4, xmax = 22, ymax = 25, zmax = 22} },
 	["Gondor Fort"] =    {build="gondorfort",   area_owner = "Gondor Guard",  area_name = "Gondor Castle", 
 		center = {x=1, y=1, z=9} },
-		--bbox = {xmin = -2, ymin = -15, zmin = -5, xmax = 23, ymax = 35, zmax = 24} },
 	["Rohan Fort"] =     {build="rohanfort",    area_owner = "Rohan Guard",   area_name = "Rohan Fort",  
 		center = {x=1, y=1, z=9} },  
-		--bbox = {xmin = -4, ymin = -15, zmin = -4, xmax = 29, ymax = 25, zmax = 29} },
 	["Orc Fort"] =       {build="orcfort",      area_owner = "Orc Guard",     area_name = "Orc Fort", 
 		center = {x=15, y=2, z=1} },       
-		-- bbox = {xmin = -4, ymin = -15, zmin = -4, xmax = 26, ymax = 45, zmax = 26} },
 	["Mallorn House"] =  {build="mallornhouse", area_owner = "Elven Guard",   area_name = "Elven House",   
 		center = {x=2, y=1, z=5} },   
-		-- bbox = {xmin = -3, ymin = -15, zmin = -3, xmax = 10, ymax = 35, zmax = 10} },
 	["Lorien House"] =   {build="lorienhouse",  area_owner = "Elven Guard",   area_name = "Elven House",  
 		center = {x=2, y=1, z=5} }, 
-		-- bbox = {xmin = -2, ymin = -15, zmin = -2, xmax = 12, ymax = 45, zmax = 12} },--Different version of "mallornhouse", made by fireuser
 	["Mirkwood House"] = {build="mirkhouse",    area_owner = "Elven Guard",   area_name = "Elven House",  
 		center = {x=5, y=2, z=1} },  
-		--bbox = {xmin = -4, ymin = -15, zmin = -4, xmax = 15, ymax = 30, zmax = 15} },
 	["Hobbit Hole"] =    {build="hobbithole",   area_owner = "Hobbit Family", area_name = "Hobbit Hole",   
 		center = {x=13, y=3, z=24} },
-		--bbox = {xmin = 0,  ymin = -15, zmin = 0, xmax = 30, ymax = 10, zmax = 20} },
 	["Dwarf House"] =    {build="dwarfhouse",   area_owner = "Dwarf Smith",   area_name = "Dwarf House", 
 		center = {x=16, y=1, z=3} },  
-		--bbox = {xmin = -5, ymin = -5, zmin = -5, xmax = 27, ymax = 13, zmax = 28} }
+
 }
 
 -- load bounding box from files
@@ -44,9 +36,6 @@ for i, v in pairs(lottmapgen_list) do
 	lottmapgen_list[i].bbox = {
 			xmin = pos1.x-v.center.x, ymin = pos1.y-v.center.y, zmin = pos1.z-v.center.z,
 			xmax = pos2.x-v.center.x, ymax = pos2.y-v.center.y, zmax = pos2.z-v.center.z}
-print(i)
-print(lottmapgen_list[i].bbox.xmin.." , "..lottmapgen_list[i].bbox.ymin.." , "..lottmapgen_list[i].bbox.zmin)
-print(lottmapgen_list[i].bbox.xmax.." , "..lottmapgen_list[i].bbox.ymax.." , "..lottmapgen_list[i].bbox.zmax)
 end
 
 -- queue to store the buildings which are waiting to be built (queue structure from https://www.lua.org/pil/11.4.html)

--- a/mods/lottmapgen/schematics.lua
+++ b/mods/lottmapgen/schematics.lua
@@ -63,7 +63,6 @@ function lottmapgen.enqueue_building(name, pos)
 	lottmapgen.queue.first = first
     lottmapgen.queue[first] = {name = name, pos = pos}
 end
-lottmapgen.enqueue_building("Orc Fort", {x=-245, y=70, z=543})
 
 -- request to fill some node below buildings
 function lottmapgen.enqueue_fill(fill)
@@ -84,8 +83,6 @@ end
 
 -- check if all the blocks that intersect the building are genrated
 function lottmapgen.check_building(bbox, pos)
-
-
 	--mapgen chuncks generate 80 blocks at a time, so we only need to checks the limits of the bounding box and
 	-- each 80 inside nodes 
 	for z=bbox.zmin, bbox.zmax+80, 80 do
@@ -163,16 +160,9 @@ end)
 
 lottmapgen.fill_bellow = function(fill)
 
-	local vm = minetest.get_voxel_manip()
-	local good = true
-
-	local ungenerated = false
-
 	
 	local pos1 = {x = fill.xmin, y = fill.y-fill_below_count, z = fill.zmin}
 	local pos2 = {x = fill.xmax, y = fill.y,                  z = fill.zmax}
-
-	local data ={}
 
 	local replace_node = {}
 	replace_node[minetest.get_content_id("lottother:dirt")]=minetest.get_content_id("default:dirt")
@@ -188,9 +178,10 @@ lottmapgen.fill_bellow = function(fill)
 
 	local mapgen_params = minetest.get_mapgen_params()
 
+	local vm = minetest.get_voxel_manip()
 	local emin, emax = vm:read_from_map(pos1, pos2)
 	local area = VoxelArea:new{MinEdge=emin, MaxEdge=emax}
-	data = vm:get_data()
+	local data = vm:get_data()
 
 	local bottom_reached = false
 
@@ -209,9 +200,6 @@ lottmapgen.fill_bellow = function(fill)
 								or cur == c_morwat or cur == c_morrivwat then 
 							data[index] = replace_to
 						else 
-							if cur == c_ignore then
-								print("BUGGGG")
-							end
 							break
 						end
 						if y==pos1.y then 

--- a/mods/lottmapgen/schematics.lua
+++ b/mods/lottmapgen/schematics.lua
@@ -44,14 +44,14 @@ end
 -- queue to store the buildings which are waiting to be built (queue structure from https://www.lua.org/pil/11.4.html)
 lottmapgen.queue = {first = 0, last = -1}
 
-local file = io.open(minetest.get_worldpath().."/building_queue", "r")
+local file = io.open(minetest.get_worldpath().."/"..SAVEDIR.."/building_queue", "r")
 if file then
 	lottmapgen.queue = minetest.deserialize(file:read("*all"))
 	file:close()
 end
 
 minetest.register_on_shutdown(function()
-	local file = io.open(minetest.get_worldpath().."/building_queue", "w")
+	local file = io.open(minetest.get_worldpath().."/"..SAVEDIR.."/building_queue", "w")
 	if (file) then
 		file:write(minetest.serialize(lottmapgen.queue))
 		file:close()

--- a/mods/lottmapgen/schematics.lua
+++ b/mods/lottmapgen/schematics.lua
@@ -72,17 +72,9 @@ function lottmapgen.dequeue_building()
 	return value
 end
 
-local check_voxel_manip = nil
-
 -- check if all the blocks that intersect the building are genrated
 function lottmapgen.check_building(bbox, pos)
 
-	if not check_voxel_manip then check_voxel_manip = minetest.get_voxel_manip() end
-
-	-- make sure the zone is loaded, so that "ignore" node are only ungenerated ones
-	local emin, emax = check_voxel_manip:read_from_map(
-		{x=bbox.xmin+pos.x, y=bbox.ymin+pos.y, z=bbox.zmin+pos.z},
-		{x=bbox.xmax+pos.x, y=bbox.ymax+pos.y, z=bbox.zmax+pos.z})
 
 	--mapgen chuncks generate 80 blocks at a time, so we only need to checks the limits of the bounding box and
 	-- each 80 inside nodes 

--- a/mods/lottmapgen/schematics.lua
+++ b/mods/lottmapgen/schematics.lua
@@ -3,21 +3,229 @@ lottmapgen = {}
 local areas_mod = minetest.get_modpath("areas")
 local protect_houses = minetest.setting_getbool("protect_structures") or false
 
+
+-- list of building, with filename and bounding box
 local lottmapgen_list = {
-    {"Angmar Fort",    "angmarfort"},
-    {"Gondor Fort",    "gondorfort"},
-    {"Rohan Fort",     "rohanfort"},
-    {"Orc Fort",       "orcfort"},
-    {"Mallorn House",  "mallornhouse"},
-    {"Lorien House",   "lorienhouse"}, --Different version of "mallornhouse", made by fireuser
-    {"Mirkwood House", "mirkhouse"},
-    {"Hobbit Hole",    "hobbithole"},
-    {"Dwarf House",    "dwarfhouse"},
+	["Angmar Fort"] =    {build="angmarfort",   area_owner = "Orc Guard",     area_name = "Angmar Fort",   
+		center = {x=9, y=2, z=3} },
+		--bbox = {xmin = -4, ymin = -15, zmin = -4, xmax = 22, ymax = 25, zmax = 22} },
+	["Gondor Fort"] =    {build="gondorfort",   area_owner = "Gondor Guard",  area_name = "Gondor Castle", 
+		center = {x=1, y=1, z=9} },
+		--bbox = {xmin = -2, ymin = -15, zmin = -5, xmax = 23, ymax = 35, zmax = 24} },
+	["Rohan Fort"] =     {build="rohanfort",    area_owner = "Rohan Guard",   area_name = "Rohan Fort",  
+		center = {x=1, y=1, z=9} },  
+		--bbox = {xmin = -4, ymin = -15, zmin = -4, xmax = 29, ymax = 25, zmax = 29} },
+	["Orc Fort"] =       {build="orcfort",      area_owner = "Orc Guard",     area_name = "Orc Fort", 
+		center = {x=15, y=2, z=1} },       
+		-- bbox = {xmin = -4, ymin = -15, zmin = -4, xmax = 26, ymax = 45, zmax = 26} },
+	["Mallorn House"] =  {build="mallornhouse", area_owner = "Elven Guard",   area_name = "Elven House",   
+		center = {x=2, y=1, z=5} },   
+		-- bbox = {xmin = -3, ymin = -15, zmin = -3, xmax = 10, ymax = 35, zmax = 10} },
+	["Lorien House"] =   {build="lorienhouse",  area_owner = "Elven Guard",   area_name = "Elven House",  
+		center = {x=2, y=1, z=5} }, 
+		-- bbox = {xmin = -2, ymin = -15, zmin = -2, xmax = 12, ymax = 45, zmax = 12} },--Different version of "mallornhouse", made by fireuser
+	["Mirkwood House"] = {build="mirkhouse",    area_owner = "Elven Guard",   area_name = "Elven House",  
+		center = {x=5, y=2, z=1} },  
+		--bbox = {xmin = -4, ymin = -15, zmin = -4, xmax = 15, ymax = 30, zmax = 15} },
+	["Hobbit Hole"] =    {build="hobbithole",   area_owner = "Hobbit Family", area_name = "Hobbit Hole",   
+		center = {x=13, y=3, z=24} },
+		--bbox = {xmin = 0,  ymin = -15, zmin = 0, xmax = 30, ymax = 10, zmax = 20} },
+	["Dwarf House"] =    {build="dwarfhouse",   area_owner = "Dwarf Smith",   area_name = "Dwarf House", 
+		center = {x=16, y=1, z=3} },  
+		--bbox = {xmin = -5, ymin = -5, zmin = -5, xmax = 27, ymax = 13, zmax = 28} }
 }
 
-for _, v in ipairs(lottmapgen_list) do
-    local builddesc = v[1]
-    local build = v[2]
+-- load bounding box from files
+for i, v in pairs(lottmapgen_list) do
+	local file = io.open(minetest.get_modpath("lottmapgen").."/schems/"..v.build..".we")
+	local value = file:read("*a")
+	file:close()
+	local pos1, pos2 = worldedit.allocate({x=0, y=0, z=0}, value)
+	lottmapgen_list[i].bbox = {
+			xmin = pos1.x-v.center.x, ymin = pos1.y-v.center.y, zmin = pos1.z-v.center.z,
+			xmax = pos2.x-v.center.x, ymax = pos2.y-v.center.y, zmax = pos2.z-v.center.z}
+print(i)
+print(lottmapgen_list[i].bbox.xmin.." , "..lottmapgen_list[i].bbox.ymin.." , "..lottmapgen_list[i].bbox.zmin)
+print(lottmapgen_list[i].bbox.xmax.." , "..lottmapgen_list[i].bbox.ymax.." , "..lottmapgen_list[i].bbox.zmax)
+end
+
+-- queue to store the buildings which are waiting to be built (queue structure from https://www.lua.org/pil/11.4.html)
+lottmapgen.queue = {first = 0, last = -1}
+
+local file = io.open(minetest.get_worldpath().."/building_queue", "r")
+if file then
+	lottmapgen.queue = minetest.deserialize(file:read("*all"))
+	file:close()
+end
+
+minetest.register_on_shutdown(function()
+	local file = io.open(minetest.get_worldpath().."/building_queue", "w")
+	if (file) then
+		file:write(minetest.serialize(lottmapgen.queue))
+		file:close()
+	end
+end)
+
+function lottmapgen.enqueue_building(name, pos)
+	local first = lottmapgen.queue.first - 1
+	lottmapgen.queue.first = first
+    lottmapgen.queue[first] = {name = name, pos = pos}
+end
+
+
+
+function lottmapgen.dequeue_building()
+	local last = lottmapgen.queue.last
+	if lottmapgen.queue.first > last then return nil end
+	local value = lottmapgen.queue[last]
+	lottmapgen.queue[last] = nil         -- to allow garbage collection
+	lottmapgen.queue.last = last - 1
+	return value
+end
+
+-- check if all the blocks that intersect the building are genrated
+function lottmapgen.check_building(bbox, pos)
+
+	-- make sure the zone is loaded, so that "ignore" node are only ungenerated ones
+	local emin, emax = minetest.get_voxel_manip():read_from_map(
+		{x=bbox.xmin+pos.x, y=bbox.ymin+pos.y, z=bbox.zmin+pos.z},
+		{x=bbox.xmax+pos.x, y=bbox.ymax+pos.y, z=bbox.zmax+pos.z})
+
+	--mapgen chuncks generate 80 blocks at a time, so we only need to checks the limits of the bounding box and
+	-- each 80 inside nodes 
+	for z=bbox.zmin, bbox.zmax+80, 80 do
+		local cur_z = pos.z + math.min(z, bbox.zmax)
+		for y=bbox.ymin, bbox.ymax+80, 80 do
+			local cur_y = pos.y + math.min(y, bbox.ymax)
+			for x=bbox.xmin, bbox.xmax+80, 80 do
+				local cur_x = pos.x + math.min(x, bbox.xmax)
+				if minetest.get_node({x = cur_x, y = cur_y, z = cur_z}).name =="ignore" then
+					return false
+				end
+			end
+		end
+	end
+		
+	return true
+end
+
+-- place building using worldedit
+function lottmapgen.place_building(building, pos)
+	--print(building.build.." placed at "..pos.x..' '..pos.y..' '..pos.z)
+	local file = io.open(minetest.get_modpath("lottmapgen").."/schems/"..building.build..".we")
+	local value = file:read("*a")
+	file:close()
+	local emin, emax = minetest.get_voxel_manip():read_from_map(
+		{x=building.bbox.xmin+pos.x, y=building.bbox.ymin+pos.y, z=building.bbox.zmin+pos.z},
+		{x=building.bbox.xmax+pos.x, y=building.bbox.ymax+pos.y, z=building.bbox.zmax+pos.z})
+	local p = {x = pos.x-building.center.x, y = pos.y-building.center.y, z = pos.z-building.center.z}
+	local count = worldedit.deserialize(p, value)
+	if ignore_count == 0 and areas_mod ~= nil and protect_houses == true then
+		local pos1 = {x = pos.x + building.bbox.xmin, y = pos.y + building.bbox.ymin, z = pos.z + building.bbox.zmin}
+		local pos2 = {x = pos.x + building.bbox.xmax, y = pos.y + building.bbox.ymax, z = pos.z + building.bbox.zmax}
+                areas:add(building.area_owner, building.area_name, pos1, pos2, nil)
+                areas:save()
+               end
+	lottmapgen.fill_bellow(building.bbox, pos)
+end
+
+
+minetest.register_globalstep(function(dtime)
+
+	-- parse the next 50 building in the queue (while not empty)
+	for count= 1, 50 do
+		local queued = lottmapgen.dequeue_building()
+		if not queued then return end
+		local building = lottmapgen_list[queued.name];
+
+		-- not all the building will be placed, ask to replace it later
+		if not lottmapgen.check_building(building.bbox, queued.pos) then 
+			lottmapgen.enqueue_building(queued.name, queued.pos)
+		else
+			-- place the building on generated nodes
+			lottmapgen.place_building(building, queued.pos)
+		end
+
+		
+	end
+
+end)
+
+-- fill of the botom nodes to avoid empty space.
+
+lottmapgen.fill_bellow = function(bbox, pos)
+
+	local vm = minetest.get_voxel_manip()
+	local good = true
+	local ungenerated = false
+
+	local sub_size = 32
+	
+	local pos1 = {x = bbox.xmin+pos.x, y = bbox.ymin-sub_size+pos.y, z = bbox.zmin+pos.z}
+	local pos2 = {x = bbox.xmax+pos.x, y = bbox.ymin+pos.y, z = bbox.zmax+pos.z}
+
+	local data ={}
+
+	local replace_node = {}
+	replace_node[minetest.get_content_id("lottother:dirt")]=minetest.get_content_id("default:dirt")
+	replace_node[minetest.get_content_id("lottother:snow")]=minetest.get_content_id("default:snowblock")
+	replace_node[minetest.get_content_id("lottother:mordor_stone")]=minetest.get_content_id("default:mordor_stone")	
+
+	local c_air = 	minetest.get_content_id("air")	
+	local c_ignore = minetest.get_content_id("ignore")	
+	local c_water = minetest.get_content_id("default:water_source")
+	local c_river_water = minetest.get_content_id("default:river_water_source")
+	local c_morwat = minetest.get_content_id("lottmapgen:blacksource")
+	local c_morrivwat = minetest.get_content_id("lottmapgen:black_river_source")
+
+	local mapgen_params = minetest.get_mapgen_params()
+	
+	while not ungenerated and good and pos1.y > mapgen_params.water_level-1000 do -- the test on pos1.y should not be met, but let's put some guaranty to avoid infinite loop
+		good = false
+		local emin, emax = vm:read_from_map(pos1, pos2)
+		local area = VoxelArea:new{MinEdge=emin, MaxEdge=emax}
+		data = vm:get_data()
+		for x = pos1.x, pos2.x do
+			for z = pos1.z, pos2.z do
+				local top_index = area:index(x, pos2.y, z)
+				local top = data[top_index]
+				local replace_to = replace_node[top]
+				if replace_to then 
+					data[top_index] = replace_to
+					for y = pos2.y-1, pos1.y, -1 do
+						local index = area:index(x, y, z)
+						local cur = data[index]
+						if cur  == c_air or cur == c_water or cur == c_river_water or cur == c_morwat or cur == c_morrivwat then 
+							data[index] = replace_to
+						else 
+							if cur == c_ignore then
+								data[area:index(x, y+1, z)] = top
+								ungenerated = true
+							end
+							break
+						end
+						if y==pos1.y then 
+							data[index] = top
+							good = true
+						end
+					end
+				end
+			end
+		end
+
+		vm:set_data(data)
+		vm:update_map()
+		vm:write_to_map()
+
+		pos2.y = pos1.y
+		pos1.y = pos2.y-sub_size
+	
+	end
+end
+
+-- folowinf function let as a way to "hack" building placement, but shouldn't be needed
+for builddesc, v in ipairs(lottmapgen_list) do
+    local build = v.build
     minetest.register_node("lottmapgen:"..build, {
         description = builddesc,
         drawtype = "glasslike",
@@ -32,10 +240,11 @@ for _, v in ipairs(lottmapgen_list) do
                 local file = io.open(minetest.get_modpath("lottmapgen").."/schems/"..build..".we")
                 local value = file:read("*a")
                 file:close()
-                local p = pointed_thing.above
-                p.x = p.x - 5
-                p.z = p.z - 2
-                local count = worldedit.deserialize(pointed_thing.above, value)
+		local p = pointed_thing.above
+		p.x = p.x-v.center.x
+		p.y = p.y-v.center.y
+		p.z = p.z-v.center.z
+                local count = worldedit.deserialize(p, value)
                 itemstack:take_item()
             end
             return itemstack
@@ -43,212 +252,6 @@ for _, v in ipairs(lottmapgen_list) do
     })
 end
 
-minetest.register_abm({
-    nodenames = {"lottmapgen:lorienhouse"},
-    interval = 1,
-	chance = 1,
-     action = function(pos)
-          if pos then
-               local file = io.open(minetest.get_modpath("lottmapgen").."/schems/lorienhouse.we")
-               local value = file:read("*a")
-               file:close()
-               local p = pos
-               p.x = p.x - 5
-               p.z = p.z - 2
-               local count = worldedit.deserialize(pos, value)
-               if areas_mod ~= nil and protect_houses == true then
-                    local pos1 = {x = pos.x - 2, y = pos.y - 15, z = pos.z - 2}
-                    local pos2 = {x = pos.x + 12, y = pos.y + 45, z = pos.z + 12}
-                    areas:add("Elven Guard", "Elven House", pos1, pos2, nil)
-                    areas:save()
-               end
-          end
-     end,
-})
-
-minetest.register_abm({
-    nodenames = {"lottmapgen:mallornhouse"},
-    interval = 1,
-	chance = 1,
-     action = function(pos)
-          if pos then
-               local file = io.open(minetest.get_modpath("lottmapgen").."/schems/mallornhouse.we")
-               local value = file:read("*a")
-               file:close()
-               local p = pos
-               p.x = p.x - 5
-               p.z = p.z - 2
-               local count = worldedit.deserialize(pos, value)
-               if areas_mod ~= nil and protect_houses == true then
-                    local pos1 = {x = pos.x - 3, y = pos.y - 15, z = pos.z - 3}
-                    local pos2 = {x = pos.x + 10, y = pos.y + 35, z = pos.z + 10}
-                    areas:add("Elven Guard", "Elven House", pos1, pos2, nil)
-                    areas:save()
-               end
-          end
-     end,
-})
-
-minetest.register_abm({
-    nodenames = {"lottmapgen:angmarfort"},
-    	interval = 5,
-	chance = 1,
-     action = function(pos)
-          if pos then
-               local file = io.open(minetest.get_modpath("lottmapgen").."/schems/angmarfort.we")
-               local value = file:read("*a")
-               file:close()
-               local p = pos
-               p.x = p.x - 5
-               p.z = p.z - 2
-               local count = worldedit.deserialize(pos, value)
-               if areas_mod ~= nil and protect_houses == true then
-                   local pos1 = {x = pos.x - 4, y = pos.y - 15, z = pos.z - 4}
-                   local pos2 = {x = pos.x + 22, y = pos.y + 25, z = pos.z + 22}
-                   areas:add("Orc Guard", "Angmar Fort", pos1, pos2, nil)
-                   areas:save()
-               end
-          end
-     end,
-})
-
-minetest.register_abm({
-    nodenames = {"lottmapgen:gondorfort"},
-	interval = 1,
-	chance = 1,
-    action = function(pos)
-        if pos then
-               local file = io.open(minetest.get_modpath("lottmapgen").."/schems/gondorfort.we")
-               local value = file:read("*a")
-               file:close()
-               local p = pos
-               p.x = p.x - 5
-               p.z = p.z - 2
-               local count = worldedit.deserialize(pos, value)
-               if areas_mod ~= nil and protect_houses == true then
-                   local pos1 = {x = pos.x + 2, y = pos.y - 15, z = pos.z - 5}
-                   local pos2 = {x = pos.x + 23, y = pos.y + 35, z = pos.z + 24}
-                   areas:add("Gondor Guard", "Gondor Castle", pos1, pos2, nil)
-                   areas:save()
-               end
-          end
-     end,
-})
-
-minetest.register_abm({
-    nodenames = {"lottmapgen:hobbithole"},
-    	interval = 1,
-	chance = 1,
-     action = function(pos)
-          if pos then
-               local file = io.open(minetest.get_modpath("lottmapgen").."/schems/hobbithole.we")
-               local value = file:read("*a")
-               file:close()
-               local p = pos
-               p.x = p.x - 5
-               p.z = p.z - 2
-               local count = worldedit.deserialize(pos, value)
-               if areas_mod ~= nil and protect_houses == true then
-                   local pos1 = {x = pos.x, y = pos.y - 15, z = pos.z}
-                   local pos2 = {x = pos.x + 30, y = pos.y + 10, z = pos.z + 20}
-                   areas:add("Hobbit Family", "Hobbit Hole", pos1, pos2, nil)
-                   areas:save()
-               end
-          end
-     end,
-})
-
-minetest.register_abm({
-    nodenames = {"lottmapgen:orcfort"},
-    interval = 1,
-	chance = 1,
-     action = function(pos)
-          if pos then
-               local file = io.open(minetest.get_modpath("lottmapgen").."/schems/orcfort.we")
-               local value = file:read("*a")
-               file:close()
-               local p = pos
-               p.x = p.x - 5
-               p.z = p.z - 2
-               local count = worldedit.deserialize(pos, value)
-               if areas_mod ~= nil and protect_houses == true then
-                   local pos1 = {x = pos.x - 4, y = pos.y - 15, z = pos.z - 4}
-                   local pos2 = {x = pos.x + 26, y = pos.y + 45, z = pos.z + 26}
-                   areas:add("Orc Guard", "Orc Fort", pos1, pos2, nil)
-                   areas:save()
-               end
-          end
-     end,
-})
-
-minetest.register_abm({
-    nodenames = {"lottmapgen:mirkhouse"},
-    interval = 5,
-	chance = 1,
-     action = function(pos)
-          if pos then
-               local file = io.open(minetest.get_modpath("lottmapgen").."/schems/mirkhouse.we")
-               local value = file:read("*a")
-               file:close()
-               local p = pos
-               p.x = p.x - 5
-               p.z = p.z - 2
-               local count = worldedit.deserialize(pos, value)
-               if areas_mod ~= nil and protect_houses == true then
-                   local pos1 = {x = pos.x - 4, y = pos.y - 15, z = pos.z - 4}
-                   local pos2 = {x = pos.x + 15, y = pos.y + 30, z = pos.z + 15}
-                   areas:add("Elven Guard", "Elven House", pos1, pos2, nil)
-                   areas:save()
-               end
-          end
-     end,
-})
-
-minetest.register_abm({
-    nodenames = {"lottmapgen:rohanfort"},
-    interval = 1,
-	chance = 1,
-     action = function(pos)
-          if pos then
-               local file = io.open(minetest.get_modpath("lottmapgen").."/schems/rohanfort.we")
-               local value = file:read("*a")
-               file:close()
-               local p = pos
-               p.x = p.x - 5
-               p.z = p.z - 2
-               local count = worldedit.deserialize(pos, value)
-               if areas_mod ~= nil and protect_houses == true then
-                   local pos1 = {x = pos.x - 4, y = pos.y - 15, z = pos.z - 4}
-                   local pos2 = {x = pos.x + 29, y = pos.y + 25, z = pos.z + 29}
-                   areas:add("Rohan Guard", "Rohan Fort", pos1, pos2, nil)
-                   areas:save()
-               end
-          end
-     end,
-})
-
-minetest.register_abm({
-    nodenames = {"lottmapgen:dwarfhouse"},
-    interval = 1,
-	chance = 1,
-	action = function(pos)
-          if pos then
-               local file = io.open(minetest.get_modpath("lottmapgen").."/schems/dwarfhouse.we")
-               local value = file:read("*a")
-               file:close()
-               local p = pos
-               p.x = p.x - 5
-               p.z = p.z - 2
-               local count = worldedit.deserialize(pos, value)
-               if areas_mod ~= nil and protect_houses == true then
-                   local pos1 = {x = pos.x - 5, y = pos.y - 5, z = pos.z - 5}
-                   local pos2 = {x = pos.x + 27, y = pos.y + 13, z = pos.z + 28}
-                   areas:add("Dwarf Smith", "Dwarf House", pos1, pos2, nil)
-                   areas:save()
-               end
-          end
-     end,
-})
 
 minetest.register_abm({
 	nodenames = {"lottmapgen:gondorfort","lottmapgen:hobbithole","lottmapgen:orcfort","lottmapgen:rohanfort","lottmapgen:mallornhouse","lottmapgen:lorienhouse"},

--- a/mods/lottmapgen/schematics.lua
+++ b/mods/lottmapgen/schematics.lua
@@ -72,11 +72,15 @@ function lottmapgen.dequeue_building()
 	return value
 end
 
+local check_voxel_manip = nil
+
 -- check if all the blocks that intersect the building are genrated
 function lottmapgen.check_building(bbox, pos)
 
+	if not check_voxel_manip then check_voxel_manip = minetest.get_voxel_manip() end
+
 	-- make sure the zone is loaded, so that "ignore" node are only ungenerated ones
-	local emin, emax = minetest.get_voxel_manip():read_from_map(
+	local emin, emax = check_voxel_manip:read_from_map(
 		{x=bbox.xmin+pos.x, y=bbox.ymin+pos.y, z=bbox.zmin+pos.z},
 		{x=bbox.xmax+pos.x, y=bbox.ymax+pos.y, z=bbox.zmax+pos.z})
 
@@ -104,9 +108,6 @@ function lottmapgen.place_building(building, pos)
 	local file = io.open(minetest.get_modpath("lottmapgen").."/schems/"..building.build..".we")
 	local value = file:read("*a")
 	file:close()
-	local emin, emax = minetest.get_voxel_manip():read_from_map(
-		{x=building.bbox.xmin+pos.x, y=building.bbox.ymin+pos.y, z=building.bbox.zmin+pos.z},
-		{x=building.bbox.xmax+pos.x, y=building.bbox.ymax+pos.y, z=building.bbox.zmax+pos.z})
 	local p = {x = pos.x-building.center.x, y = pos.y-building.center.y, z = pos.z-building.center.z}
 	local count = worldedit.deserialize(p, value)
 	if ignore_count == 0 and areas_mod ~= nil and protect_houses == true then
@@ -212,7 +213,7 @@ lottmapgen.fill_bellow = function(bbox, pos)
 	end
 end
 
--- folowinf function let as a way to "hack" building placement, but shouldn't be needed
+-- folowing function let as a way to "hack" building placement, but shouldn't be needed
 for builddesc, v in ipairs(lottmapgen_list) do
     local build = v.build
     minetest.register_node("lottmapgen:"..build, {


### PR DESCRIPTION
The building were placed using an abm, which made them pop at the last moment.

Now, they are added to a queue which is parsed in a global step, adding the building only when all the surounding areas has been generated.

I also changed the way the nodes under the building fill the empty space, to make it faster 