### PR TITLE
Replaced/removed get_mapgen_settings, set_mapgen_settings and colorize when deprecated

### DIFF
--- a/mods/darkage/mapgen.lua
+++ b/mods/darkage/mapgen.lua
@@ -153,7 +153,15 @@ local function generate_claylike(data, varea, name, minp, maxp, seed, chance, mi
 	end
 end
 
-local seed = minetest.get_mapgen_setting("seed")
+local seed
+if minetest.get_mapgen_setting then
+	seed = minetest.get_mapgen_setting('seed')
+else
+	local mg_params = minetest.get_mapgen_params()
+	if mg_params then
+		seed = mg_params.seed
+	end
+end
 
 
 -- Generate desert stone with iron in derset.

--- a/mods/default/mapgen.lua
+++ b/mods/default/mapgen.lua
@@ -1,20 +1,48 @@
 -- mods/default/mapgen.lua
 
-local mapgen_name = minetest.get_mapgen_setting("mg_name")
+local mapgen_name
+if minetest.get_mapgen_setting then
+	mapgen_name = minetest.get_mapgen_setting('mg_name')
+else
+	local mg_params = minetest.get_mapgen_params()
+	if mg_params then
+		mapgen_name = mg_params.mgname
+	end
+end
 local lott_v6 = minetest.setting_getbool("lott_v6") or false
 
 if mapgen_name == "singlenode" or (mapgen_name == "v6" and lott_v6 ~= true) then
-	minetest.set_mapgen_setting("mg_name", "v7", true)
+	if minetest.set_mapgen_setting then
+		minetest.set_mapgen_setting("mg_name", "v7", true)
+	else
+		local mg_params = minetest.get_mapgen_params()
+		mg_params.mgname = "v7"
+		minetest.set_mapgen_params(mg_params)
+	end
 end
 
-local flags = minetest.get_mapgen_setting("mgv7_spflags")
+local flags
+if minetest.get_mapgen_setting then
+	flags = minetest.get_mapgen_setting('mgv7_spflags')
+else
+	local mg_params = minetest.get_mapgen_params()
+	if mg_params then
+		flags = mg_params.flags
+	end
+end
 
 if flags ~= nil then
 	local c1, c2 = flags:find("floatlands")
 
 	if c1 and c2 and not flags:find("nofloatlands") then
-		minetest.set_mapgen_setting("mgv7_spflags",
-			flags:sub(1, c1-1) .. flags:sub(c2+1), true)
+		if minetest.set_mapgen_setting then
+			minetest.set_mapgen_setting("mgv7_spflags",
+				flags:sub(1, c1-1) .. flags:sub(c2+1), true)
+		else
+			local mg_params = minetest.get_mapgen_params()
+			mg_params.flags = flags:sub(1, c1-1) .. flags:sub(c2+1)
+			minetest.set_mapgen_params(mg_params)
+		end
 	end
 end
 
@@ -70,7 +98,15 @@ minetest.register_alias("mapgen_stair_sandstonebrick", "stairs:stair_cobble")
 -- Ore generation
 --
 
-local wl = minetest.get_mapgen_setting("water_level")
+local wl
+if minetest.get_mapgen_setting then
+	wl = minetest.get_mapgen_setting('water_level')
+else
+	local mg_params = minetest.get_mapgen_params()
+	if mg_params then
+		wl = mg_params.water_level
+	end
+end
 
 minetest.register_ore({
 	ore_type       = "scatter",

--- a/mods/lottmapgen/deco.lua
+++ b/mods/lottmapgen/deco.lua
@@ -1,4 +1,12 @@
-local water_level = minetest.get_mapgen_setting("water_level")
+local water_level
+if minetest.get_mapgen_setting then
+	water_level = minetest.get_mapgen_setting('water_level')
+else
+	local mg_params = minetest.get_mapgen_params()
+	if mg_params then
+		water_level = mg_params.water_level
+	end
+end
 
 minetest.set_gen_notify("dungeon")
 

--- a/mods/lottmapgen/init.lua
+++ b/mods/lottmapgen/init.lua
@@ -99,7 +99,15 @@ local nbuf_random
 local dbuf
 local p2dbuf
 
-local water_level = minetest.get_mapgen_setting("water_level")
+local water_level
+if minetest.get_mapgen_setting then
+	water_level = minetest.get_mapgen_setting('water_level')
+else
+	local mg_params = minetest.get_mapgen_params()
+	if mg_params then
+		water_level = mg_params.water_level
+	end
+end
 
 dofile(minetest.get_modpath("lottmapgen").."/nodes.lua")
 dofile(minetest.get_modpath("lottmapgen").."/functions.lua")

--- a/mods/lottmapgen/schematics.lua
+++ b/mods/lottmapgen/schematics.lua
@@ -176,7 +176,15 @@ lottmapgen.fill_bellow = function(fill)
 	local c_morwat = minetest.get_content_id("lottmapgen:blacksource")
 	local c_morrivwat = minetest.get_content_id("lottmapgen:black_river_source")
 
-	local water_level = minetest.get_mapgen_setting("water_level")
+	local water_level
+	if minetest.get_mapgen_setting then
+		water_level = minetest.get_mapgen_setting('water_level')
+	else
+		local mg_params = minetest.get_mapgen_params()
+		if mg_params then
+			water_level = mg_params.water_level
+		end
+	end
 
 	local vm = minetest.get_voxel_manip()
 	local emin, emax = vm:read_from_map(pos1, pos2)

--- a/mods/lottores/mapgen.lua
+++ b/mods/lottores/mapgen.lua
@@ -1,4 +1,12 @@
-local wl = minetest.get_mapgen_setting("water_level")
+local wl
+if minetest.get_mapgen_setting then
+	wl = minetest.get_mapgen_setting('water_level')
+else
+	local mg_params = minetest.get_mapgen_params()
+	if mg_params then
+		wl = mg_params.water_level
+	end
+end
 
 minetest.register_ore({
 	ore_type       = "scatter",

--- a/mods/lottother/credits.lua
+++ b/mods/lottother/credits.lua
@@ -3,27 +3,36 @@ local blue = "#03159e"
 local red = "#9e0310"
 local purple = "#67039e"
 
+local colorize
+if minetest.colorize then
+    colorize = minetest.colorize
+else
+    colorize = function(color, msg)
+        return msg
+    end
+end
+
 local credits = "size[10,8]" ..
     "background[10,8;1,1;gui_formbg.png;true]" ..
-    "label[0.5,0.25;" .. minetest.colorize("black", "LOTT Credits:") .. "]" ..
-    "label[1,1;" .. minetest.colorize(green, "Main Developers:") .. "]" ..
-    "label[1.5,1.5;" .. minetest.colorize(green, "fishyWET") .. "]" ..
-    "label[1.5,2;" .. minetest.colorize(green, "Amaz") .. "]" ..
-    "label[1,3;" .. minetest.colorize(blue, "Other Developers:") .. "]" ..
-    "label[1.5,3.5;" .. minetest.colorize(blue, "catninja") .. "]" ..
-    "label[1.5,4;" .. minetest.colorize(blue, "Flipsels") .. "]" ..
-    "label[1.5,4.5;" .. minetest.colorize(blue, "MadTux") .. "]" ..
-    "label[1.5,5;" .. minetest.colorize(blue, "BadToad2000") .. "]" ..
-    "label[1.5,5.5;" .. minetest.colorize(blue, "lumidify") .. "]" ..
-    "label[1.5,6;" .. minetest.colorize(blue, "narrnika") .. "]" ..
-    "label[5,1;" .. minetest.colorize(red, "Model Makers:") .. "]" ..
-    "label[5.5,1.5;" .. minetest.colorize(red, "STHGOM") .. "]" ..
-    "label[5.5,2;" .. minetest.colorize(red, "AspireMint") .. "]" ..
-    "label[5,3;" .. minetest.colorize(purple, "Main Texture Makers:") .. "]" ..
-    "label[5.5,3.5;" .. minetest.colorize(purple, "philipbenr") .. "]" ..
-    "label[5.5,4;" .. minetest.colorize(purple, "Gabo") .. "]" ..
-    "label[5.5,4.5;" .. minetest.colorize(purple, "Many others!") .. "]" ..
-    "button[5.5,5.5;2,1;mods;" .. minetest.colorize("yellow", "More info!!") .. "]"
+    "label[0.5,0.25;" .. colorize("black", "LOTT Credits:") .. "]" ..
+    "label[1,1;" .. colorize(green, "Main Developers:") .. "]" ..
+    "label[1.5,1.5;" .. colorize(green, "fishyWET") .. "]" ..
+    "label[1.5,2;" .. colorize(green, "Amaz") .. "]" ..
+    "label[1,3;" .. colorize(blue, "Other Developers:") .. "]" ..
+    "label[1.5,3.5;" .. colorize(blue, "catninja") .. "]" ..
+    "label[1.5,4;" .. colorize(blue, "Flipsels") .. "]" ..
+    "label[1.5,4.5;" .. colorize(blue, "MadTux") .. "]" ..
+    "label[1.5,5;" .. colorize(blue, "BadToad2000") .. "]" ..
+    "label[1.5,5.5;" .. colorize(blue, "lumidify") .. "]" ..
+    "label[1.5,6;" .. colorize(blue, "narrnika") .. "]" ..
+    "label[5,1;" .. colorize(red, "Model Makers:") .. "]" ..
+    "label[5.5,1.5;" .. colorize(red, "STHGOM") .. "]" ..
+    "label[5.5,2;" .. colorize(red, "AspireMint") .. "]" ..
+    "label[5,3;" .. colorize(purple, "Main Texture Makers:") .. "]" ..
+    "label[5.5,3.5;" .. colorize(purple, "philipbenr") .. "]" ..
+    "label[5.5,4;" .. colorize(purple, "Gabo") .. "]" ..
+    "label[5.5,4.5;" .. colorize(purple, "Many others!") .. "]" ..
+    "button[5.5,5.5;2,1;mods;" .. colorize("yellow", "More info!!") .. "]"
 
 local purple2 = "#c804cc"
 local green2 = green
@@ -42,7 +51,7 @@ local mods = {
 
 local more_credits = "size[11,8]" ..
     "background[11,8;1,1;gui_formbg.png;true]" ..
-    "label[0.25,0.25;" .. minetest.colorize("gray", "Mod License Information:") .. "]"
+    "label[0.25,0.25;" .. colorize("gray", "Mod License Information:") .. "]"
 
 local colours = {
     "red",
@@ -64,7 +73,7 @@ for i,v in pairs(mods) do
     end
     more_credits = more_credits ..
         "button[".. distance .. "," .. count .. ";2,1;" ..
-        v .. ";" .. minetest.colorize(colours[count], v) .. "]"
+        v .. ";" .. colorize(colours[count], v) .. "]"
     if count >= #mods then
         count = 0
         distance = 0.5
@@ -91,7 +100,7 @@ minetest.register_on_player_receive_fields(function(player, formname, fields)
                 local form = "size[12,10]" ..
                     "background[10,8;1,1;gui_formbg.png;true]" ..
                     "label[0,-0.2;" ..
-                    minetest.colorize("black", "License of " .. v .. " mod:") .. "]" ..
+                    colorize("black", "License of " .. v .. " mod:") .. "]" ..
                     "button[10,1;2,1;back_to_mods;Back]" ..
                     "textlist[0,0.5;10,9;license;"
                 local file = io.open(minetest.get_modpath(v) .. "/license.txt")

--- a/mods/lottother/rings/gems.lua
+++ b/mods/lottother/rings/gems.lua
@@ -78,7 +78,15 @@ minetest.register_node("lottother:red_gem_ore", {
 
 -- Mapgen stuff
 
-local wl = minetest.get_mapgen_setting("water_level")
+local wl
+if minetest.get_mapgen_setting then
+	wl = minetest.get_mapgen_setting('water_level')
+else
+	local mg_params = minetest.get_mapgen_params()
+	if mg_params then
+		wl = mg_params.water_level
+	end
+end
 
 minetest.register_ore({
 	ore_type       = "scatter",


### PR DESCRIPTION
get_mapgen_settings, set_mapgen_settings and colorize are not available at 0.4.14, so they should be replaced/removed.
As far as I can see, colorize came back at 0.4.15, as core.colorize (instead of minetest.colorize). In that case  mods/lottother/credits.lua can be easily modified to use such function (I have not Minetest 0.4.15, so I cannot check)
I hope it may helps!