### PR TITLE
Fix mushroom growth

### DIFF
--- a/mods/lottfarming/blue.lua
+++ b/mods/lottfarming/blue.lua
@@ -156,7 +156,7 @@ minetest.register_abm({
 	action = function(pos, node)
 		pos.y = pos.y-1
 		if minetest.get_node(pos).name ~= "lottfarming:decay_tree"
-		and minetest.get_node(pos).name ~= "default_tree" then
+		and minetest.get_node(pos).name ~= "default:tree" then
 			return
 		end
 		pos.y = pos.y+1

--- a/mods/lottfarming/blue.lua
+++ b/mods/lottfarming/blue.lua
@@ -176,29 +176,11 @@ minetest.register_abm({
 	interval = 30,
 	chance = 10,
 	action = function(pos, node)
-		pos.x = pos.x-1
-		x = num:next(1, 3)
-		if x > 1 then
-			pos.x = pos.x+1
-			if x > 2 then
-				pos.x = pos.x+1
-			end
-		end
-		pos.z=pos.z-1
-		z = num:next(1, 3)
-		if z > 1 then
-			pos.z = pos.z+1
-			if z > 2 then
-				pos.z = pos.z+1
-			end
-		end
+		pos.x = pos.x + num:next(-1, 1)
+		pos.z = pos.z + num:next(-1, 1)
 		if minetest.get_node(pos).name=="air" then
 			pos.y = pos.y-1
 			name = minetest.get_node(pos).name
-			if name=="default:tree" then
-				pos.y=pos.y+1
-				minetest.set_node(pos, {name='lottfarming:blue_mushroom_3', param2 = 9})
-			end
 			if name=="default:tree" then
 				pos.y=pos.y+1
 				minetest.set_node(pos, {name='lottfarming:blue_mushroom_3', param2 = 9})
@@ -210,10 +192,6 @@ minetest.register_abm({
 					pos.y=pos.y+1
 					minetest.set_node(pos, {name='lottfarming:blue_mushroom_3', param2 = 9})
 				end
-				if name=="default:tree" then
-					pos.y=pos.y+1
-					minetest.set_node(pos, {name='lottfarming:blue_mushroom_3', param2 = 9})
-				end
 			end
 
 		end
@@ -221,10 +199,6 @@ minetest.register_abm({
 		if minetest.get_node(pos).name=="air" then
 			pos.y = pos.y-1
 			name = minetest.get_node(pos).name
-			if name=="default:tree" then
-				pos.y=pos.y+1
-				minetest.set_node(pos, {name='lottfarming:blue_mushroom_3', param2 = 9})
-			end
 			if name=="default:tree" then
 				pos.y=pos.y+1
 				minetest.set_node(pos, {name='lottfarming:blue_mushroom_3', param2 = 9})

--- a/mods/lottfarming/brown.lua
+++ b/mods/lottfarming/brown.lua
@@ -160,22 +160,8 @@ minetest.register_abm({
 	interval = 30,
 	chance = 10,
 	action = function(pos, node)
-		pos.x = pos.x-1
-		x = num:next(1, 3)
-		if x > 1 then
-			pos.x = pos.x+1
-			if x > 2 then
-				pos.x = pos.x+1
-			end
-		end
-		pos.z=pos.z-1
-		z = num:next(1, 3)
-		if z > 1 then
-			pos.z = pos.z+1
-			if z > 2 then
-				pos.z = pos.z+1
-			end
-		end
+		pos.x = pos.x + num:next(-1, 1)
+		pos.z = pos.z + num:next(-1, 1)
 		if minetest.get_node(pos).name=="air" then
 			pos.y = pos.y-1
 			name = minetest.get_node(pos).name
@@ -183,17 +169,9 @@ minetest.register_abm({
 				pos.y=pos.y+1
 				minetest.set_node(pos, {name='lottfarming:brown_mushroom_3', param2 = 9})
 			end
-			if name=="default:tree" then
-				pos.y=pos.y+1
-				minetest.set_node(pos, {name='lottfarming:brown_mushroom_3', param2 = 9})
-			end
 			if name=="air" then
 				pos.y=pos.y-1
 				name = minetest.get_node(pos).name
-				if name=="default:tree" then
-						pos.y=pos.y+1
-						minetest.set_node(pos, {name='lottfarming:brown_mushroom_3', param2 = 9})
-				end
 				if name=="default:tree" then
 					pos.y=pos.y+1
 					minetest.set_node(pos, {name='lottfarming:brown_mushroom_3', param2 = 9})
@@ -204,10 +182,6 @@ minetest.register_abm({
 		if minetest.get_node(pos).name=="air" then
 			pos.y = pos.y-1
 			name = minetest.get_node(pos).name
-			if name=="default:tree" then
-				pos.y=pos.y+1
-				minetest.set_node(pos, {name='lottfarming:brown_mushroom_3', param2 = 9})
-			end
 			if name=="default:tree" then
 				pos.y=pos.y+1
 				minetest.set_node(pos, {name='lottfarming:brown_mushroom_3', param2 = 9})

--- a/mods/lottfarming/brown.lua
+++ b/mods/lottfarming/brown.lua
@@ -140,7 +140,7 @@ minetest.register_abm({
 	action = function(pos, node)
 		pos.y = pos.y-1
 		if minetest.get_node(pos).name ~= "lottfarming:decay_tree"
-		and minetest.get_node(pos).name ~= "default_tree" then
+		and minetest.get_node(pos).name ~= "default:tree" then
 			return
 		end
 		pos.y = pos.y+1

--- a/mods/lottfarming/green.lua
+++ b/mods/lottfarming/green.lua
@@ -184,29 +184,11 @@ minetest.register_abm({
 	interval = 30,
 	chance = 10,
 	action = function(pos, node)
-		pos.x = pos.x-1
-		x = num:next(1, 3)
-		if x > 1 then
-			pos.x = pos.x+1
-			if x > 2 then
-				pos.x = pos.x+1
-			end
-		end
-		pos.z=pos.z-1
-		z = num:next(1, 3)
-		if z > 1 then
-			pos.z = pos.z+1
-			if z > 2 then
-				pos.z = pos.z+1
-			end
-		end
+		pos.x = pos.x + num:next(-1, 1)
+		pos.z = pos.z + num:next(-1, 1)
 		if minetest.get_node(pos).name=="air" then
 			pos.y = pos.y-1
 			name = minetest.get_node(pos).name
-			if name=="default:tree" then
-				pos.y=pos.y+1
-				minetest.set_node(pos, {name='lottfarming:green_mushroom_3', param2 = 9})
-			end
 			if name=="default:tree" then
 				pos.y=pos.y+1
 				minetest.set_node(pos, {name='lottfarming:green_mushroom_3', param2 = 9})
@@ -218,9 +200,6 @@ minetest.register_abm({
 					pos.y=pos.y+1
 					minetest.set_node(pos, {name='lottfarming:green_mushroom_3', param2 = 9})
 				end
-				if name=="default:tree" then																		pos.y=pos.y+1
-					minetest.set_node(pos, {name='lottfarming:green_mushroom_3', param2 = 9})
-				end
 			end
 
 		end
@@ -228,10 +207,6 @@ minetest.register_abm({
 		if minetest.get_node(pos).name=="air" then
 			pos.y = pos.y-1
 			name = minetest.get_node(pos).name
-			if name=="default:tree" then
-				pos.y=pos.y+1
-				minetest.set_node(pos, {name='lottfarming:green_mushroom_3', param2 = 9})
-			end
 			if name=="default:tree" then
 				pos.y=pos.y+1
 				minetest.set_node(pos, {name='lottfarming:green_mushroom_3', param2 = 9})

--- a/mods/lottfarming/green.lua
+++ b/mods/lottfarming/green.lua
@@ -164,7 +164,7 @@ minetest.register_abm({
 	action = function(pos, node)
 		pos.y = pos.y-1
 		if minetest.get_node(pos).name ~= "lottfarming:decay_tree"
-		and minetest.get_node(pos).name ~= "default_tree" then
+		and minetest.get_node(pos).name ~= "default:tree" then
 			return
 		end
 		pos.y = pos.y+1

--- a/mods/lottfarming/red.lua
+++ b/mods/lottfarming/red.lua
@@ -154,7 +154,7 @@ minetest.register_abm({
 	action = function(pos, node)
 		pos.y = pos.y-1
 		if minetest.get_node(pos).name ~= "lottfarming:decay_tree"
-		and minetest.get_node(pos).name ~= "default_tree" then
+		and minetest.get_node(pos).name ~= "default:tree" then
 			return
 		end
 		pos.y = pos.y+1

--- a/mods/lottfarming/red.lua
+++ b/mods/lottfarming/red.lua
@@ -175,29 +175,11 @@ minetest.register_abm({
 	interval = 30,
 	chance = 10,
 	action = function(pos, node)
-		pos.x = pos.x-1
-		x = num:next(1, 3)
-		if x > 1 then
-			pos.x = pos.x+1
-			if x > 2 then
-				pos.x = pos.x+1
-			end
-		end
-		pos.z=pos.z-1
-		z = num:next(1, 3)
-		if z > 1 then
-			pos.z = pos.z+1
-			if z > 2 then
-				pos.z = pos.z+1
-			end
-		end
+		pos.x = pos.x + num:next(-1, 1)
+		pos.z = pos.z + num:next(-1, 1)
 		if minetest.get_node(pos).name=="air" then
 			pos.y = pos.y-1
 			name = minetest.get_node(pos).name
-			if name=="default:tree" then
-				pos.y=pos.y+1
-				minetest.set_node(pos, {name='lottfarming:red_mushroom_3', param2 = 9})
-			end
 			if name=="default:tree" then
 				pos.y=pos.y+1
 				minetest.set_node(pos, {name='lottfarming:red_mushroom_3', param2 = 9})
@@ -209,10 +191,6 @@ minetest.register_abm({
 					pos.y=pos.y+1
 					minetest.set_node(pos, {name='lottfarming:red_mushroom_3', param2 = 9})
 				end
-				if name=="default:tree" then
-					pos.y=pos.y+1
-					minetest.set_node(pos, {name='lottfarming:red_mushroom_3', param2 = 9})
-				end
 			end
 
 		end
@@ -220,10 +198,6 @@ minetest.register_abm({
 		if minetest.get_node(pos).name=="air" then
 			pos.y = pos.y-1
 			name = minetest.get_node(pos).name
-			if name=="default:tree" then
-				pos.y=pos.y+1
-				minetest.set_node(pos, {name='lottfarming:red_mushroom_3', param2 = 9})
-			end
 			if name=="default:tree" then
 				pos.y=pos.y+1
 				minetest.set_node(pos, {name='lottfarming:red_mushroom_3', param2 = 9})

--- a/mods/lottfarming/white.lua
+++ b/mods/lottfarming/white.lua
@@ -156,7 +156,8 @@ minetest.register_abm({
 	chance = chance,
 	action = function(pos, node)
 		pos.y = pos.y-1
-		if minetest.get_node(pos).name ~= "lottfarming:decay_tree" and minetest.get_node(pos).name ~= "default_tree" then
+		if minetest.get_node(pos).name ~= "lottfarming:decay_tree"
+		and minetest.get_node(pos).name ~= "default:tree" then
 			return
 		end
 		pos.y = pos.y+1

--- a/mods/lottfarming/white.lua
+++ b/mods/lottfarming/white.lua
@@ -178,29 +178,11 @@ minetest.register_abm({
 	interval = 30,
 	chance = 10,
 	action = function(pos, node)
-		pos.x = pos.x-1
-		x = num:next(1, 3)
-		if x > 1 then
-			pos.x = pos.x+1
-			if x > 2 then
-				pos.x = pos.x+1
-			end
-		end
-		pos.z=pos.z-1
-		z = num:next(1, 3)
-		if z > 1 then
-			pos.z = pos.z+1
-			if z > 2 then
-				pos.z = pos.z+1
-			end
-		end
+		pos.x = pos.x + num:next(-1, 1)
+		pos.z = pos.z + num:next(-1, 1)
 		if minetest.get_node(pos).name=="air" then
 			pos.y = pos.y-1
 			name = minetest.get_node(pos).name
-			if name=="default:tree" then
-				pos.y=pos.y+1
-				minetest.set_node(pos, {name='lottfarming:white_mushroom_3', param2 = 9})
-			end
 			if name=="default:tree" then
 				pos.y=pos.y+1
 				minetest.set_node(pos, {name='lottfarming:white_mushroom_3', param2 = 9})
@@ -212,10 +194,6 @@ minetest.register_abm({
 					pos.y=pos.y+1
 					minetest.set_node(pos, {name='lottfarming:white_mushroom_3', param2 = 9})
 				end
-				if name=="default:tree" then
-					pos.y=pos.y+1
-					minetest.set_node(pos, {name='lottfarming:white_mushroom_3', param2 = 9})
-				end
 			end
 
 		end
@@ -223,10 +201,6 @@ minetest.register_abm({
 		if minetest.get_node(pos).name=="air" then
 			pos.y = pos.y-1
 			name = minetest.get_node(pos).name
-			if name=="default:tree" then
-				pos.y=pos.y+1
-				minetest.set_node(pos, {name='lottfarming:white_mushroom_3', param2 = 9})
-			end
 			if name=="default:tree" then
 				pos.y=pos.y+1
 				minetest.set_node(pos, {name='lottfarming:white_mushroom_3', param2 = 9})


### PR DESCRIPTION
This PR contains 2 commits:

- (Simplify and) fix the mushroom spreading code so that they no longer spread in strange stacks, where the 2nd mushroom floated above the 1st.
- Mushrooms never fully grew up, because the code checked for "default_tree" instead of the correct "default:tree". Fixed that, too.