### PR TITLE
Fix a few undeclared global variable LUA warnings in lottmobs

### DIFF
--- a/mods/lottmobs/functions.lua
+++ b/mods/lottmobs/functions.lua
@@ -51,15 +51,15 @@ local npc_guard_attack = function(self)
 
                 if entity_type == "player" or entity_type == "npc" or entity_type == "monster" then
 
-                        s = self.object:getpos()
-                        p = player:getpos()
-                        sp = s
+                        local s = self.object:getpos()
+                        local p = player:getpos()
+                        local sp = s
 
                         -- aim higher to make looking up hills more realistic
                         p.y = p.y + 1
                         sp.y = sp.y + 1
 
-                        dist = get_distance(p, s)
+                        local dist = get_distance(p, s)
 
                         if dist < self.view_range then
 
@@ -129,15 +129,15 @@ local npc_attack = function(self)
 
                 if entity_type == "player" or entity_type == "npc" or entity_type == "monster" then
 
-                        s = self.object:getpos()
-                        p = player:getpos()
-                        sp = s
+                        local s = self.object:getpos()
+                        local p = player:getpos()
+                        local sp = s
 
                         -- aim higher to make looking up hills more realistic
                         p.y = p.y + 1
                         sp.y = sp.y + 1
 
-                        dist = get_distance(p, s)
+                        local dist = get_distance(p, s)
 
                         if dist < self.view_range then
 

--- a/mods/lottmobs/hobbits.lua
+++ b/mods/lottmobs/hobbits.lua
@@ -55,6 +55,21 @@ function lottmobs.register_hobbit(n, hpmin, hpmax, textures, wv, rv, damg, arm, 
         lottmobs.register_guard_craftitem("lottmobs:hobbit"..n, "Hobbit Guard", "lottmobs_hobbit_guard"..n.."_inv.png")
 end
 
+local drops = {
+	{name = "lottfarming:pipeweed_cooked",
+	chance = 5,
+	min = 1,
+	max = 5,},
+	{name = "lottfarming:pipe",
+	chance = 20,
+	min = 1,
+	max = 1,},
+	{name = "lottweapons:steel_dagger",
+	chance = 100,
+	min = 1,
+	max = 1,},
+}
+
 --Normal Hobbits
 local textures1 = {
     {"lottmobs_hobbit_1.png", "lottarmor_trans.png", "lottarmor_trans.png", "lottarmor_trans.png", "lottarmor_trans.png"},


### PR DESCRIPTION
Most warnings were fixed by just adding "local", this one however

> WARNING[Main]: Undeclared global variable "drops" accessed at ...

was fixed by defining the missing drops for Hobbits. But nothing valuable,
didn't want to affect gameplay balance, just typical Hobbit stuff: pipes,
pipeweed and, very rarely, a steel dagger.