### PR TITLE
avoid warnings

### DIFF
--- a/mods/WorldEdit/worldedit/serialization.lua
+++ b/mods/WorldEdit/worldedit/serialization.lua
@@ -153,7 +153,7 @@ local function load_schematic(value)
 			})
 		end
 	elseif version == 4 or version == 5 then -- Nested table format
-		if not jit then
+		if not (rawget(_G, "jit") and jit) then
 			-- This is broken for larger tables in the current version of LuaJIT
 			nodes = minetest.deserialize(content)
 		else

--- a/mods/lottmobs/functions.lua
+++ b/mods/lottmobs/functions.lua
@@ -1,4 +1,4 @@
-local invisibility = invisibility or {}
+local invisibility = (rawget(_G, "invisibility") and invisibility) or {}
 local damage_enabled = minetest.setting_getbool("enable_damage")
 
 local get_distance = function(a, b)

--- a/mods/mobs/api.lua
+++ b/mods/mobs/api.lua
@@ -43,7 +43,7 @@ end
 mobs.intllib = S
 
 -- Invisibility mod
-local invisibility = invisibility or {}
+local invisibility = (rawget(_G, "invisibility") and invisibility) or {}
 
 -- Load settings
 local damage_enabled = minetest.setting_getbool("enable_damage")


### PR DESCRIPTION
This is being done by checking possibly undefined globals before accessing them.