### PR TITLE
Fix couple bugs with undeclared variables

### DIFF
--- a/mods/lottclasses/immunity.lua
+++ b/mods/lottclasses/immunity.lua
@@ -61,7 +61,7 @@ minetest.register_on_joinplayer(function(player)
 			minetest.after(i, function()
 				local immunity_c = meta:get_string("lott:immunity")
 				if player == nil then return end
-				if not tonumber(immunity) then return end
+				if not tonumber(immunity_c) then return end
 				meta:set_string("lott:immunity", tonumber(immunity_c) - 1)
 			end)
 		end

--- a/mods/lottweapons/special.lua
+++ b/mods/lottweapons/special.lua
@@ -29,6 +29,7 @@ minetest.register_tool("lottweapons:balrog_whip", {
 		minetest.get_background_escape_sequence("darkred"),
 	inventory_image = "lottweapons_balrog_whip.png^[transform3",
 	on_use = function(itemstack, user, pointed_thing)
+		local name = user:get_player_name()
 		if pointed_thing.type == "nothing" then
 			local dir = user:get_look_dir()
 			local pos = user:get_pos()
@@ -39,7 +40,7 @@ minetest.register_tool("lottweapons:balrog_whip", {
 					z = pos.z + (dir.z * i),
 				}
 				if minetest.get_node(new_pos).name == "air"	and
-				not minetest.is_protected(new_pos, user:get_player_name()) then
+				not minetest.is_protected(new_pos, name) then
 					minetest.set_node(new_pos, {name = "fire:basic_flame"})
 				end
 			end


### PR DESCRIPTION
1. Fix nil check on immunity by providing correct variable name.
2. Fix permission check by introducing local variable for player name. Line 100 was using undeclared `name` variable instead of player name.